### PR TITLE
Add coverage report and some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.log
 .idea
 .settings
+.classpath
+cobertura.ser
 grails-willcrisis-*.zip
 grails-willcrisis-*.zip.sha1
 plugin.xml

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,7 +18,7 @@ grails.project.dependency.resolution = {
             export = false
         }
         if (Environment.current == Environment.TEST) {
-            test(':cache:1.1.8', ":cache-ehcache:1.0.5") {
+            test(':cache:1.1.8', ":cache-ehcache:1.0.5", ":code-coverage:1.2.7") {
                 export = false
             }
         }
@@ -28,3 +28,8 @@ grails.project.dependency.resolution = {
 
 grails.project.repos.default = "willcrisis"
 grails.project.groupId = "com.willcrisis.plugins"
+
+coverage {
+	enabledByDefault = true
+	xml = true
+}


### PR DESCRIPTION
Add the code-coverage plugin to generate coverage report.
Create more tests to PersonService.
I Didn't find a way to test mailService neither shareService. Sorry. :disappointed: 